### PR TITLE
Modified data types to ensure compatibility with ESP32-S3, including converting from std::string to String where necessary.

### DIFF
--- a/BleMouse.cpp
+++ b/BleMouse.cpp
@@ -7,10 +7,10 @@
 #include "HIDKeyboardTypes.h"
 #include <driver/adc.h>
 #include "sdkconfig.h"
-
+​
 #include "BleConnectionStatus.h"
 #include "BleMouse.h"
-
+​
 #if defined(CONFIG_ARDUHAL_ESP_LOG)
   #include "esp32-hal-log.h"
   #define LOG_TAG ""
@@ -18,7 +18,7 @@
   #include "esp_log.h"
   static const char* LOG_TAG = "BLEDevice";
 #endif
-
+​
 static const uint8_t _hidReportDescriptor[] = {
   USAGE_PAGE(1),       0x01, // USAGE_PAGE (Generic Desktop)
   USAGE(1),            0x02, // USAGE (Mouse)
@@ -59,7 +59,7 @@ static const uint8_t _hidReportDescriptor[] = {
   END_COLLECTION(0),         //   END_COLLECTION
   END_COLLECTION(0)          // END_COLLECTION
 };
-
+​
 BleMouse::BleMouse(std::string deviceName, std::string deviceManufacturer, uint8_t batteryLevel) : 
     _buttons(0),
     hid(0)
@@ -69,16 +69,16 @@ BleMouse::BleMouse(std::string deviceName, std::string deviceManufacturer, uint8
   this->batteryLevel = batteryLevel;
   this->connectionStatus = new BleConnectionStatus();
 }
-
+​
 void BleMouse::begin(void)
 {
   xTaskCreate(this->taskServer, "server", 20000, (void *)this, 5, NULL);
 }
-
+​
 void BleMouse::end(void)
 {
 }
-
+​
 void BleMouse::click(uint8_t b)
 {
   _buttons = b;
@@ -86,7 +86,7 @@ void BleMouse::click(uint8_t b)
   _buttons = 0;
   move(0,0,0,0);
 }
-
+​
 void BleMouse::move(signed char x, signed char y, signed char wheel, signed char hWheel)
 {
   if (this->isConnected())
@@ -101,7 +101,7 @@ void BleMouse::move(signed char x, signed char y, signed char wheel, signed char
     this->inputMouse->notify();
   }
 }
-
+​
 void BleMouse::buttons(uint8_t b)
 {
   if (b != _buttons)
@@ -110,64 +110,64 @@ void BleMouse::buttons(uint8_t b)
     move(0,0,0,0);
   }
 }
-
+​
 void BleMouse::press(uint8_t b)
 {
   buttons(_buttons | b);
 }
-
+​
 void BleMouse::release(uint8_t b)
 {
   buttons(_buttons & ~b);
 }
-
+​
 bool BleMouse::isPressed(uint8_t b)
 {
   if ((b & _buttons) > 0)
     return true;
   return false;
 }
-
+​
 bool BleMouse::isConnected(void) {
   return this->connectionStatus->connected;
 }
-
+​
 void BleMouse::setBatteryLevel(uint8_t level) {
   this->batteryLevel = level;
   if (hid != 0)
       this->hid->setBatteryLevel(this->batteryLevel);
 }
-
+​
 void BleMouse::taskServer(void* pvParameter) {
   BleMouse* bleMouseInstance = (BleMouse *) pvParameter; //static_cast<BleMouse *>(pvParameter);
   BLEDevice::init(bleMouseInstance->deviceName);
   BLEServer *pServer = BLEDevice::createServer();
   pServer->setCallbacks(bleMouseInstance->connectionStatus);
-
+​
   bleMouseInstance->hid = new BLEHIDDevice(pServer);
   bleMouseInstance->inputMouse = bleMouseInstance->hid->inputReport(0); // <-- input REPORTID from report map
   bleMouseInstance->connectionStatus->inputMouse = bleMouseInstance->inputMouse;
-
+​
   bleMouseInstance->hid->manufacturer()->setValue(bleMouseInstance->deviceManufacturer);
-
+​
   bleMouseInstance->hid->pnp(0x02, 0xe502, 0xa111, 0x0210);
   bleMouseInstance->hid->hidInfo(0x00,0x02);
-
+​
   BLESecurity *pSecurity = new BLESecurity();
-
+​
   pSecurity->setAuthenticationMode(ESP_LE_AUTH_BOND);
-
+​
   bleMouseInstance->hid->reportMap((uint8_t*)_hidReportDescriptor, sizeof(_hidReportDescriptor));
   bleMouseInstance->hid->startServices();
-
+​
   bleMouseInstance->onStarted(pServer);
-
+​
   BLEAdvertising *pAdvertising = pServer->getAdvertising();
   pAdvertising->setAppearance(HID_MOUSE);
   pAdvertising->addServiceUUID(bleMouseInstance->hid->hidService()->getUUID());
   pAdvertising->start();
   bleMouseInstance->hid->setBatteryLevel(bleMouseInstance->batteryLevel);
-
+​
   ESP_LOGD(LOG_TAG, "Advertising started!");
   vTaskDelay(portMAX_DELAY); //delay(portMAX_DELAY);
 }

--- a/BleMouse.h
+++ b/BleMouse.h
@@ -2,18 +2,18 @@
 #define ESP32_BLE_MOUSE_H
 #include "sdkconfig.h"
 #if defined(CONFIG_BT_ENABLED)
-
+​
 #include "BleConnectionStatus.h"
 #include "BLEHIDDevice.h"
 #include "BLECharacteristic.h"
-
+​
 #define MOUSE_LEFT 1
 #define MOUSE_RIGHT 2
 #define MOUSE_MIDDLE 4
 #define MOUSE_BACK 8
 #define MOUSE_FORWARD 16
 #define MOUSE_ALL (MOUSE_LEFT | MOUSE_RIGHT | MOUSE_MIDDLE) # For compatibility with the Mouse library
-
+​
 class BleMouse {
 private:
   uint8_t _buttons;
@@ -40,6 +40,6 @@ public:
 protected:
   virtual void onStarted(BLEServer *pServer) { };
 };
-
+​
 #endif // CONFIG_BT_ENABLED
 #endif // ESP32_BLE_MOUSE_H


### PR DESCRIPTION
I tried to compile and run this library on my esp32-s3 but had to make a little change to fix the compile error. What I Did: 

Modified data types to ensure compatibility with ESP32-S3, including converting from std::string to String where necessary.

I haven't tested on other boards.