### PR TITLE
Fix Compatibility with std::string in ESP32_BLE_Mouse Library

### DIFF
--- a/BleMouse.cpp
+++ b/BleMouse.cpp
@@ -140,7 +140,7 @@ void BleMouse::setBatteryLevel(uint8_t level) {
 
 void BleMouse::taskServer(void* pvParameter) {
   BleMouse* bleMouseInstance = (BleMouse *) pvParameter; //static_cast<BleMouse *>(pvParameter);
-  BLEDevice::init(bleMouseInstance->deviceName);
+  BLEDevice::init(String(bleMouseInstance->deviceName.c_str()));
   BLEServer *pServer = BLEDevice::createServer();
   pServer->setCallbacks(bleMouseInstance->connectionStatus);
 
@@ -148,7 +148,8 @@ void BleMouse::taskServer(void* pvParameter) {
   bleMouseInstance->inputMouse = bleMouseInstance->hid->inputReport(0); // <-- input REPORTID from report map
   bleMouseInstance->connectionStatus->inputMouse = bleMouseInstance->inputMouse;
 
-  bleMouseInstance->hid->manufacturer()->setValue(bleMouseInstance->deviceManufacturer);
+  bleMouseInstance->hid->manufacturer()->setValue(String(bleMouseInstance->deviceManufacturer.c_str()));
+
 
   bleMouseInstance->hid->pnp(0x02, 0xe502, 0xa111, 0x0210);
   bleMouseInstance->hid->hidInfo(0x00,0x02);


### PR DESCRIPTION
This pull request resolves compatibility issues in the ESP32_BLE_Mouse library, ensuring smoother integration and functionality with Arduino functions that require the String type. The following fixes were implemented:

Key Changes:
BLEDevice::init():

Fixed a type mismatch by converting std::string to String using .c_str().
Updated line 143 in BleMouse.cpp:
cpp
Copy code
BLEDevice::init(String(bleMouseInstance->deviceName.c_str()));
BLECharacteristic::setValue():

Resolved a similar issue by converting std::string to String.
Updated line 151 in BleMouse.cpp:

bleMouseInstance->hid->manufacturer()->setValue(String(bleMouseInstance->deviceManufacturer.c_str()));


**Reason for Changes:**

The library was originally passing std::string (C++ Standard Library) to functions that require String (Arduino-specific type). This caused compilation errors on Arduino platforms. These changes ensure type compatibility and make the library fully functional without modifying the user's project code.

**Testing:**

Verified the fixes on an ESP32-based project.
Ensured smooth initialization of BLE and successful updates to the characteristic values.
Tested with multiple BLE devices and ensured backward compatibility.

**Impact:**

Fixes critical compilation issues caused by type mismatches.
Ensures seamless use of the library on the latest ESP32 Arduino Core.
No breaking changes introduced.

**Recommendation to Maintainers:**

Consider adding explicit support for std::string in future versions for broader compatibility.