### PR TITLE
Update BleMouse.cpp

### DIFF
--- a/BleMouse.cpp
+++ b/BleMouse.cpp
@@ -140,7 +140,7 @@ void BleMouse::setBatteryLevel(uint8_t level) {
 
 void BleMouse::taskServer(void* pvParameter) {
   BleMouse* bleMouseInstance = (BleMouse *) pvParameter; //static_cast<BleMouse *>(pvParameter);
-  BLEDevice::init(bleMouseInstance->deviceName);
+  BLEDevice::init(bleMouseInstance->deviceName.c_str());
   BLEServer *pServer = BLEDevice::createServer();
   pServer->setCallbacks(bleMouseInstance->connectionStatus);
 
@@ -148,7 +148,7 @@ void BleMouse::taskServer(void* pvParameter) {
   bleMouseInstance->inputMouse = bleMouseInstance->hid->inputReport(0); // <-- input REPORTID from report map
   bleMouseInstance->connectionStatus->inputMouse = bleMouseInstance->inputMouse;
 
-  bleMouseInstance->hid->manufacturer()->setValue(bleMouseInstance->deviceManufacturer);
+  bleMouseInstance->hid->manufacturer()->setValue(String(bleMouseInstance->deviceManufacturer.c_str()));
 
   bleMouseInstance->hid->pnp(0x02, 0xe502, 0xa111, 0x0210);
   bleMouseInstance->hid->hidInfo(0x00,0x02);


### PR DESCRIPTION
Same as BleKeyboard.cpp

🛠️ Fix for ESP32_BLE_Mouse Compatibility with Latest ESP32 BLE Library This repository includes a patched version of the BleMouse.cpp file from the ESP32_BLE_Mouse library. It fixes compilation errors that occur when using ESP32 core version 3.x, caused by the use of std::string where the BLE library expects Arduino String objects.

✅ What’s Fixed:
Replaced std::string with String(…).c_str() or direct String() conversion

Ensured compatibility with BLEDevice::init() and BLECharacteristic::setValue() calls

Useful for users facing similar errors when compiling the BLE Mouse library with updated ESP32 toolchains.